### PR TITLE
Fix for empty search

### DIFF
--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -31,7 +31,7 @@ export class HomePage {
     this.loading = true;
     this.noResults = false;
 
-    if (q.length == 0) {
+    if (q.replace(/\s/g, '').length == 0) {
       this.noResults = true
       this.loading = false
     } else {


### PR DESCRIPTION
This commit adds a conditional in the `searchFunction` that checks if
the length of the query is == 0. If it is it will set the results as
if there were no results.